### PR TITLE
Feat azure

### DIFF
--- a/images/stretch/Dockerfile
+++ b/images/stretch/Dockerfile
@@ -62,7 +62,8 @@ RUN pip install --upgrade --no-cache-dir \
         virtualenv \
         docker-compose \
         PyYAML==3.12 \
-        awscli \ 
+        awscli \
+        azure-cli \
         cookiecutter
 
 # Install NPM Packages

--- a/utilities/codeontap/Dockerfile
+++ b/utilities/codeontap/Dockerfile
@@ -12,6 +12,7 @@ ENV AUTOMATION_DIR=/opt/codeontap/automation/jenkins/aws
 ENV GENERATION_BASE_DIR=/opt/codeontap/generation
 ENV GENERATION_DIR=/opt/codeontap/generation/aws
 ENV GENERATION_STARTUP_DIR=/opt/codeontap/startup
+ENV GENERATION_PLUGIN_DIRS=/opt/codeontap/plugins
 
 # Directory set up and file copying 
 RUN mkdir -p /build/scripts


### PR DESCRIPTION
Environment variable GENERATION_PLUGIN_DIRS is already used by CodeOnTap during template creation. This PR will set this variable to existing plugins directory, allowing the lookup to occur without additional configuration.

``` Existing usage within createTemplate.sh
      ${GENERATION_DIR}/freemarker.sh \
        -d "${template_dir}" \
        ${GENERATION_PRE_PLUGIN_DIRS:+ -d "${GENERATION_PRE_PLUGIN_DIRS}"} \
        -d "${GENERATION_BASE_DIR}/engine" \
        -d "${GENERATION_BASE_DIR}/providers" \
        ${GENERATION_PLUGIN_DIRS:+ -d "${GENERATION_PLUGIN_DIRS}"} \
		    -t "${template}" \
        -o "${template_result_file}" \
        "${args[@]}" || return $?
```

Also added the Azure CLI to the pip installation packages.