### PR TITLE
Feature - Azure Pipelines Agent

### DIFF
--- a/images/stretch/hooks/build
+++ b/images/stretch/hooks/build
@@ -18,7 +18,7 @@ docker build -t "${DOCKER_REPO}:${DOCKER_TAG%-*}-jenkins" -t "${DOCKER_REPO}:${D
 
 docker build -t "${DOCKER_REPO}:${DOCKER_TAG%-*}-azpipeline" -t "${DOCKER_REPO}:${DOCKER_TAG}-azpipeline" -t "${DOCKER_REPO}:${DOCKER_TAG}-azpipeline" -t "${DOCKER_REPO}:${DOCKER_TAG}-azpipeline-agent" \
     --build-arg BASE_IMAGE="${DOCKER_REPO}:${DOCKER_TAG}" \
-    -f ../../utilities/jenkins/agent-jnlp/Dockerfile ../../ || exit $?
+    -f ../../utilities/azure-pipelines/agent/Dockerfile ../../ || exit $?
 
 # gen3 builder  
 docker build -t "${DOCKER_REPO}:${DOCKER_TAG%-*}-builder" -t "${DOCKER_REPO}:${DOCKER_TAG}-builder" -t "${DOCKER_REPO}:${DOCKER_TAG}-builder" \
@@ -31,7 +31,7 @@ docker build -t "${DOCKER_REPO}:${DOCKER_TAG%-*}-jenkins-builder" -t "${DOCKER_R
 
 docker build -t "${DOCKER_REPO}:${DOCKER_TAG%-*}-azpipeline-builder" -t "${DOCKER_REPO}:${DOCKER_TAG}-azpipeline-builder" -t "${DOCKER_REPO}:${DOCKER_TAG}-azpipeline-builder" -t "${DOCKER_REPO}:${DOCKER_TAG}-azpipeline-builder-agent" \
     --build-arg BASE_IMAGE="${DOCKER_REPO}:${DOCKER_TAG}" \
-    -f ../../utilities/jenkins/agent-jnlp/Dockerfile ../../ || exit $?
+    -f ../../utilities/azure-pipelines/agent/Dockerfile ../../ || exit $?
 
 # gen3 builder meteor
 docker build -t "${DOCKER_REPO}:${DOCKER_TAG%-*}-builder-meteor" -t "${DOCKER_REPO}:${DOCKER_TAG}-builder-meteor" -t "${DOCKER_REPO}:${DOCKER_TAG}-builder-meteor" \
@@ -44,7 +44,7 @@ docker build  -t "${DOCKER_REPO}:${DOCKER_TAG}-jenkins-agent-jnlp-builder-meteor
 
 docker build  -t "${DOCKER_REPO}:${DOCKER_TAG}-azpipeline-builder-meteor-nocache"  \
     --build-arg BASE_IMAGE="${DOCKER_REPO}:${DOCKER_TAG}-builder-meteor" \
-    -f ../../utilities/jenkins/agent-jnlp/Dockerfile ../../ || exit $?
+    -f ../../utilities/azure-pipelines/agent/Dockerfile ../../ || exit $?
 
 docker build -t "${DOCKER_REPO}:${DOCKER_TAG%-*}-jenkins-builder-meteor" -t "${DOCKER_REPO}:${DOCKER_TAG}-jenkins-builder-meteor" -t "${DOCKER_REPO}:${DOCKER_TAG}-jenkins-builder-meteor" -t "${DOCKER_REPO}:${DOCKER_TAG}-jenkins-agent-jnlp-builder-meteor" \
     --build-arg BASE_IMAGE="${DOCKER_REPO}:${DOCKER_TAG}-jenkins-agent-jnlp-builder-meteor-nocache" \
@@ -52,4 +52,4 @@ docker build -t "${DOCKER_REPO}:${DOCKER_TAG%-*}-jenkins-builder-meteor" -t "${D
 
 docker build -t "${DOCKER_REPO}:${DOCKER_TAG%-*}-azpipeline-builder-meteor" -t "${DOCKER_REPO}:${DOCKER_TAG}-azpipeline-builder-meteor" -t "${DOCKER_REPO}:${DOCKER_TAG}-azpipeline-builder-meteor" -t "${DOCKER_REPO}:${DOCKER_TAG}-azpipeline-builder-meteor" \
     --build-arg BASE_IMAGE="${DOCKER_REPO}:${DOCKER_TAG}-jenkins-agent-jnlp-builder-meteor-nocache" \
-    -f ./builder/meteor/cache-packages/Dockerfile ../../ || exit $?
+    -f ../../utilities/azure-pipelines/agent/Dockerfile ../../ || exit $?

--- a/images/stretch/hooks/build
+++ b/images/stretch/hooks/build
@@ -16,6 +16,10 @@ docker build -t "${DOCKER_REPO}:${DOCKER_TAG%-*}-jenkins" -t "${DOCKER_REPO}:${D
     --build-arg BASE_IMAGE="${DOCKER_REPO}:${DOCKER_TAG}" \
     -f ../../utilities/jenkins/agent-jnlp/Dockerfile ../../ || exit $?
 
+docker build -t "${DOCKER_REPO}:${DOCKER_TAG%-*}-azpipeline" -t "${DOCKER_REPO}:${DOCKER_TAG}-azpipeline" -t "${DOCKER_REPO}:${DOCKER_TAG}-azpipeline" -t "${DOCKER_REPO}:${DOCKER_TAG}-azpipeline-agent" \
+    --build-arg BASE_IMAGE="${DOCKER_REPO}:${DOCKER_TAG}" \
+    -f ../../utilities/jenkins/agent-jnlp/Dockerfile ../../ || exit $?
+
 # gen3 builder  
 docker build -t "${DOCKER_REPO}:${DOCKER_TAG%-*}-builder" -t "${DOCKER_REPO}:${DOCKER_TAG}-builder" -t "${DOCKER_REPO}:${DOCKER_TAG}-builder" \
     --build-arg BASE_IMAGE="${DOCKER_REPO}:${DOCKER_TAG}" \
@@ -23,6 +27,10 @@ docker build -t "${DOCKER_REPO}:${DOCKER_TAG%-*}-builder" -t "${DOCKER_REPO}:${D
 
 docker build -t "${DOCKER_REPO}:${DOCKER_TAG%-*}-jenkins-builder" -t "${DOCKER_REPO}:${DOCKER_TAG}-jenkins-builder" -t "${DOCKER_REPO}:${DOCKER_TAG}-jenkins-builder" -t "${DOCKER_REPO}:${DOCKER_TAG}-jenkins-agent-jnlp-builder" \
     --build-arg BASE_IMAGE="${DOCKER_REPO}:${DOCKER_TAG}-builder" \
+    -f ../../utilities/jenkins/agent-jnlp/Dockerfile ../../ || exit $?
+
+docker build -t "${DOCKER_REPO}:${DOCKER_TAG%-*}-azpipeline-builder" -t "${DOCKER_REPO}:${DOCKER_TAG}-azpipeline-builder" -t "${DOCKER_REPO}:${DOCKER_TAG}-azpipeline-builder" -t "${DOCKER_REPO}:${DOCKER_TAG}-azpipeline-builder-agent" \
+    --build-arg BASE_IMAGE="${DOCKER_REPO}:${DOCKER_TAG}" \
     -f ../../utilities/jenkins/agent-jnlp/Dockerfile ../../ || exit $?
 
 # gen3 builder meteor
@@ -34,6 +42,14 @@ docker build  -t "${DOCKER_REPO}:${DOCKER_TAG}-jenkins-agent-jnlp-builder-meteor
     --build-arg BASE_IMAGE="${DOCKER_REPO}:${DOCKER_TAG}-builder-meteor" \
     -f ../../utilities/jenkins/agent-jnlp/Dockerfile ../../ || exit $?
 
+docker build  -t "${DOCKER_REPO}:${DOCKER_TAG}-azpipeline-builder-meteor-nocache"  \
+    --build-arg BASE_IMAGE="${DOCKER_REPO}:${DOCKER_TAG}-builder-meteor" \
+    -f ../../utilities/jenkins/agent-jnlp/Dockerfile ../../ || exit $?
+
 docker build -t "${DOCKER_REPO}:${DOCKER_TAG%-*}-jenkins-builder-meteor" -t "${DOCKER_REPO}:${DOCKER_TAG}-jenkins-builder-meteor" -t "${DOCKER_REPO}:${DOCKER_TAG}-jenkins-builder-meteor" -t "${DOCKER_REPO}:${DOCKER_TAG}-jenkins-agent-jnlp-builder-meteor" \
+    --build-arg BASE_IMAGE="${DOCKER_REPO}:${DOCKER_TAG}-jenkins-agent-jnlp-builder-meteor-nocache" \
+    -f ./builder/meteor/cache-packages/Dockerfile ../../ || exit $?
+
+docker build -t "${DOCKER_REPO}:${DOCKER_TAG%-*}-azpipeline-builder-meteor" -t "${DOCKER_REPO}:${DOCKER_TAG}-azpipeline-builder-meteor" -t "${DOCKER_REPO}:${DOCKER_TAG}-azpipeline-builder-meteor" -t "${DOCKER_REPO}:${DOCKER_TAG}-azpipeline-builder-meteor" \
     --build-arg BASE_IMAGE="${DOCKER_REPO}:${DOCKER_TAG}-jenkins-agent-jnlp-builder-meteor-nocache" \
     -f ./builder/meteor/cache-packages/Dockerfile ../../ || exit $?

--- a/images/stretch/hooks/push
+++ b/images/stretch/hooks/push
@@ -9,6 +9,11 @@ docker push "${DOCKER_REPO}:${DOCKER_TAG}-jenkins" || exit $?
 docker push "${DOCKER_REPO}:${DOCKER_TAG%-*}-jenkins" || exit $?
 docker push "${DOCKER_REPO}:${DOCKER_TAG}-jenkins-agent-jnlp" || exit $?
 
+# gen3 base - Azure Pipelines
+docker push "${DOCKER_REPO}:${DOCKER_TAG}-azpipeline" || exit $?
+docker push "${DOCKER_REPO}:${DOCKER_TAG%-*}-azpipeline" || exit $?
+docker push "${DOCKER_REPO}:${DOCKER_TAG}-azpipeline-agent" || exit $?
+
 # gen3 builder 
 docker push "${DOCKER_REPO}:${DOCKER_TAG}-builder" || exit $?
 docker push "${DOCKER_REPO}:${DOCKER_TAG%-*}-builder" || exit $?
@@ -18,6 +23,11 @@ docker push "${DOCKER_REPO}:${DOCKER_TAG}-jenkins-builder" || exit $?
 docker push "${DOCKER_REPO}:${DOCKER_TAG%-*}-jenkins-builder" || exit $?
 docker push "${DOCKER_REPO}:${DOCKER_TAG}-jenkins-agent-jnlp-builder" || exit $?
 
+# gen3 builder - Azure Pipelines
+docker push "${DOCKER_REPO}:${DOCKER_TAG}-azpipeline-builder" || exit $?
+docker push "${DOCKER_REPO}:${DOCKER_TAG%-*}-azpipeline-builder" || exit $?
+docker push "${DOCKER_REPO}:${DOCKER_TAG}-azpipeline-agent-builder" || exit $?
+
 # gen3 builder meteor
 docker push "${DOCKER_REPO}:${DOCKER_TAG}-builder-meteor" || exit $?
 docker push "${DOCKER_REPO}:${DOCKER_TAG%-*}-builder-meteor" || exit $?
@@ -26,3 +36,8 @@ docker push "${DOCKER_REPO}:${DOCKER_TAG%-*}-builder-meteor" || exit $?
 docker push "${DOCKER_REPO}:${DOCKER_TAG}-jenkins-builder-meteor" || exit $?
 docker push "${DOCKER_REPO}:${DOCKER_TAG%-*}-jenkins-builder-meteor" || exit $?
 docker push "${DOCKER_REPO}:${DOCKER_TAG}-jenkins-agent-jnlp-builder-meteor" || exit $?
+
+# gen3 builder meteor - Azure Pipelines
+docker push "${DOCKER_REPO}:${DOCKER_TAG}-azpipeline-builder-meteor" || exit $?
+docker push "${DOCKER_REPO}:${DOCKER_TAG%-*}-azpipeline-builder-meteor" || exit $?
+docker push "${DOCKER_REPO}:${DOCKER_TAG}-azpipeline-agent-builder-meteor" || exit $?

--- a/scripts/azpipelines-agent/start
+++ b/scripts/azpipelines-agent/start
@@ -1,0 +1,92 @@
+#!/bin/bash
+set -e
+
+if [ -z "$AZP_URL" ]; then
+  echo 1>&2 "error: missing AZP_URL environment variable"
+  exit 1
+fi
+
+if [ -z "$AZP_TOKEN_FILE" ]; then
+  if [ -z "$AZP_TOKEN" ]; then
+    echo 1>&2 "error: missing AZP_TOKEN environment variable"
+    exit 1
+  fi
+
+  AZP_TOKEN_FILE=/azp/.token
+  echo -n $AZP_TOKEN > "$AZP_TOKEN_FILE"
+fi
+
+unset AZP_TOKEN
+
+if [ -n "$AZP_WORK" ]; then
+  mkdir -p "$AZP_WORK"
+fi
+
+rm -rf /azp/agent
+mkdir /azp/agent
+cd /azp/agent
+
+export AGENT_ALLOW_RUNASROOT="1"
+
+cleanup() {
+  if [ -e config.sh ]; then
+    print_header "Cleanup. Removing Azure Pipelines agent..."
+
+    ./config.sh remove --unattended \
+      --auth PAT \
+      --token $(cat "$AZP_TOKEN_FILE")
+  fi
+}
+
+print_header() {
+  lightcyan='\033[1;36m'
+  nocolor='\033[0m'
+  echo -e "${lightcyan}$1${nocolor}"
+}
+
+# Let the agent ignore the token env variables
+export VSO_AGENT_IGNORE=AZP_TOKEN,AZP_TOKEN_FILE
+
+print_header "1. Determining matching Azure Pipelines agent..."
+
+AZP_AGENT_RESPONSE=$(curl -LsS \
+  -u user:$(cat "$AZP_TOKEN_FILE") \
+  -H 'Accept:application/json;api-version=3.0-preview' \
+  "$AZP_URL/_apis/distributedtask/packages/agent?platform=linux-x64")
+
+if echo "$AZP_AGENT_RESPONSE" | jq . >/dev/null 2>&1; then
+  AZP_AGENTPACKAGE_URL=$(echo "$AZP_AGENT_RESPONSE" \
+    | jq -r '.value | map([.version.major,.version.minor,.version.patch,.downloadUrl]) | sort | .[length-1] | .[3]')
+fi
+
+if [ -z "$AZP_AGENTPACKAGE_URL" -o "$AZP_AGENTPACKAGE_URL" == "null" ]; then
+  echo 1>&2 "error: could not determine a matching Azure Pipelines agent - check that account '$AZP_URL' is correct and the token is valid for that account"
+  exit 1
+fi
+
+print_header "2. Downloading and installing Azure Pipelines agent..."
+
+curl -LsS $AZP_AGENTPACKAGE_URL | tar -xz & wait $!
+
+source ./env.sh
+
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
+
+print_header "3. Configuring Azure Pipelines agent..."
+
+./config.sh --unattended \
+  --agent "${AZP_AGENT_NAME:-$(hostname)}" \
+  --url "$AZP_URL" \
+  --auth PAT \
+  --token $(cat "$AZP_TOKEN_FILE") \
+  --pool "${AZP_POOL:-Default}" \
+  --work "${AZP_WORK:-_work}" \
+  --replace \
+  --acceptTeeEula & wait $!
+
+print_header "4. Running Azure Pipelines agent..."
+
+# `exec` the node runtime so it's aware of TERM and INT signals
+# AgentService.js understands how to handle agent self-update and restart
+exec ./externals/node/bin/node ./bin/AgentService.js interactive

--- a/scripts/azpipelines-agent/start
+++ b/scripts/azpipelines-agent/start
@@ -12,7 +12,7 @@ if [ -z "$AZP_TOKEN_FILE" ]; then
     exit 1
   fi
 
-  AZP_TOKEN_FILE=/azp/.token
+  AZP_TOKEN_FILE=/home/azp/.token
   echo -n $AZP_TOKEN > "$AZP_TOKEN_FILE"
 fi
 
@@ -22,9 +22,9 @@ if [ -n "$AZP_WORK" ]; then
   mkdir -p "$AZP_WORK"
 fi
 
-rm -rf /azp/agent
-mkdir /azp/agent
-cd /azp/agent
+rm -rf /home/azp/agent
+mkdir /home/azp/agent
+cd /home/azp/agent
 
 export AGENT_ALLOW_RUNASROOT="1"
 
@@ -87,6 +87,6 @@ print_header "3. Configuring Azure Pipelines agent..."
 
 print_header "4. Running Azure Pipelines agent..."
 
-# `exec` the node runtime so it's aware of TERM and INT signals
-# AgentService.js understands how to handle agent self-update and restart
-exec ./externals/node/bin/node ./bin/AgentService.js interactive
+# Run the Agent Listener and wait - this correctly removes the Agent from the 
+# Agent Pool in Azure DevOps when shut-down through "docker stop <container_name>"
+./bin/Agent.Listener run & wait $!

--- a/utilities/azure-pipelines/agent/Dockerfile
+++ b/utilities/azure-pipelines/agent/Dockerfile
@@ -1,0 +1,40 @@
+# -------------------------------------------------------
+# Azure Pipelines Agent Dockerfile
+# -------------------------------------------------------
+ARG BASE_IMAGE=codeontap/gen3:latest-stretch
+
+FROM ${BASE_IMAGE} AS azpipeline-agent
+
+USER root
+
+ARG PIPELINESUID=1000
+ARG DOCKERGID=497
+
+# Workaround for docker in docker permissions - ECS seems to use 497 for the group Id
+RUN useradd -u ${PIPELINESUID} --shell /bin/bash --create-home azpipelines \
+  && groupmod -g "${DOCKERGID}" docker \
+  && usermod -G docker azpipelines \
+  && echo '#Allow Azure Pipelines user to install extra packages' \
+  && echo 'azpipelines ALL = NOPASSWD : /usr/bin/apt-get' >> /etc/sudoers
+
+# https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/docker?view=azure-devops#linux
+RUN apt-get update \
+&& apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        jq \
+        git \
+        iputils-ping \
+        libcurl3 \
+        libicu55 \
+        libunwind8 \
+        netcat \
+        zip \
+        unzip
+
+WORKDIR /home/azpipelines
+COPY scripts/azpipelines-agent/start /home/azpipelines/start
+RUN chmod +x /home/azpipelines/start
+USER azpipelines
+
+ENTRYPOINT [ "/home/azpipelines/start" ]

--- a/utilities/azure-pipelines/agent/Dockerfile
+++ b/utilities/azure-pipelines/agent/Dockerfile
@@ -11,11 +11,11 @@ ARG PIPELINESUID=1000
 ARG DOCKERGID=497
 
 # Workaround for docker in docker permissions - ECS seems to use 497 for the group Id
-RUN useradd -u ${PIPELINESUID} --shell /bin/bash --create-home azpipelines \
+RUN useradd -u ${PIPELINESUID} --shell /bin/bash --create-home azp \
   && groupmod -g "${DOCKERGID}" docker \
-  && usermod -G docker azpipelines \
+  && usermod -G docker azp \
   && echo '#Allow Azure Pipelines user to install extra packages' \
-  && echo 'azpipelines ALL = NOPASSWD : /usr/bin/apt-get' >> /etc/sudoers
+  && echo 'azp ALL = NOPASSWD : /usr/bin/apt-get' >> /etc/sudoers
 
 # https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/docker?view=azure-devops#linux
 RUN apt-get update \
@@ -26,15 +26,16 @@ RUN apt-get update \
         git \
         iputils-ping \
         libcurl3 \
-        libicu55 \
         libunwind8 \
         netcat \
+        unzip \
         zip \
-        unzip
+&& rm -rf /var/lib/apt/lists/*
 
-WORKDIR /home/azpipelines
-COPY scripts/azpipelines-agent/start /home/azpipelines/start
-RUN chmod +x /home/azpipelines/start
-USER azpipelines
+COPY scripts/azpipelines-agent/start /usr/local/bin/start
+RUN chmod 755 /usr/local/bin/start
+RUN chmod +x /usr/local/bin/start
+WORKDIR /home/azp
+USER azp
 
-ENTRYPOINT [ "/home/azpipelines/start" ]
+ENTRYPOINT [ "/usr/local/bin/start" ]


### PR DESCRIPTION
Impliments container images for an Azure Pipelines Agent. This can be used to undertake build or release workloads within Azure DevOps.

# Running the container
``` bash
docker run -e AZP_URL="https://dev.azure.com/myAwesomeCompany/" -e AZP_TOKEN="1234567890" -e AZP_AGENT_NAME=MyAwesomeAgent azpipeline
```

# A note on stopping the container
When terminated unexpectedly the Agent will remain in the Agent Pool within Azure DevOps. It will then potentially be allocated work to do long after the container is destroyed. When shut-down through `"docker stop <container-name"` however, the agent is cleaned up from the server.