### PR TITLE
resolving az-cli dependency issues

### DIFF
--- a/images/stretch/Dockerfile
+++ b/images/stretch/Dockerfile
@@ -64,6 +64,7 @@ RUN pip install --upgrade --no-cache-dir \
         PyYAML==3.12 \
         awscli \
         azure-cli \
+        requests \
         cookiecutter
 
 # Install NPM Packages


### PR DESCRIPTION
Presently all calls to the Az CLI are accompanied by a warning message that two dependencies are on unsupported versions. This has been identified on the az-cli github page (Azure/azure-cli#9257) as an issue with the pip installer method specifically, where the dependencies have not been pinned to a specific version. The resolution method for now is to reinstall "requests" package through pip, which identifies the correct dependencies and reverts to them.

At a later stage, once the az-cli pip installation method has its dependencies correctly set we can remove this.

Example warning message:

```
(Info) [2019-11-07_00:05:39] Provisioning State is "Running".

(Info)     Retry in 30 seconds...
/usr/local/lib/python3.5/dist-packages/requests/__init__.py:91: RequestsDependencyWarning: urllib3 (1.25.6) or chardet (3.0.4) doesn't match a supported version!
  RequestsDependencyWarning)
```