### PR TITLE
Azure CLI Extensions

### DIFF
--- a/images/stretch/Dockerfile
+++ b/images/stretch/Dockerfile
@@ -93,6 +93,9 @@ RUN pip install --upgrade --no-cache-dir \
         requests \
         cookiecutter
 
+# Install Azure CLI Extensions
+RUN az extension add --name front-door
+
 # rbenv requirements
 ENV RUBY_VERSION 2.5.1
 


### PR DESCRIPTION
The Azure CLI uses some extensions to manage some of the lesser-used resources. The cli itself is used to perform the fetch/install of these extensions. This PR creates a new layer on the dockerfile that can be used for any future cli extensions used by codeontap.