### PR TITLE
<fix>Reduce docker image overlap builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,12 +10,11 @@ pipeline {
     options {
         timestamps()
         durabilityHint('PERFORMANCE_OPTIMIZED')
-        quietPeriod(0)
+        quietPeriod(300)
         disableConcurrentBuilds()
         parallelsAlwaysFailFast()
         timeout(time: 6, unit: 'HOURS')
     }
-
 
     environment {
         DOCKERHUB_CREDENTIALS = credentials('dockerhub')


### PR DESCRIPTION
Adds the quiet period back on for docker images. Since we have a number of repo's triggering docker builds and the docker build process always clones from a tag or the latest master branch we don't need to build the docker image on every commit, just at the end of a window of gen3 activity 